### PR TITLE
fix bug in parsing entry detail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.afrunt</groupId>
     <artifactId>jach</artifactId>
-    <version>0.2.5.2-cx-SNAPSHOT</version>
+    <version>0.2.5.3-cx-SNAPSHOT</version>
 
     <name>jACH</name>
     <description>Open source library for working with ACH files</description>

--- a/src/main/java/com/afrunt/jach/domain/detail/CTXEntryDetail.java
+++ b/src/main/java/com/afrunt/jach/domain/detail/CTXEntryDetail.java
@@ -35,12 +35,6 @@ public class CTXEntryDetail extends NonIATEntryDetail {
     private String discretionaryData;
     private String receivingCompanyName;
 
-    @Override
-    @Values("1")
-    public Short getAddendaRecordIndicator() {
-        return 1;
-    }
-
     @ACHField(start = 39, length = 15, name = NonIATEntryDetail.IDENTIFICATION_NUMBER)
     public String getIdentificationNumber() {
         return identificationNumber;


### PR DESCRIPTION
rarely CFSB sends ACH CTX entry detail record with addenda record indicator = 0 (no addenda).
that could cause exception when parsing the file.